### PR TITLE
Don't use latest version for react-native-root-toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "query-string": "^4.3.2",
     "react": "15.4.2",
     "react-native": "0.42.3",
-    "react-native-root-toast": "^1.0.5",
+    "react-native-root-toast": "1.0.5",
     "react-native-scrollable-tab-view": "^0.7.2",
     "react-native-storage": "^0.1.5",
     "react-native-vector-icons": "^4.0.0",


### PR DESCRIPTION
在安装的时候不要使用root-toast最新版本，否则会造成ViewPropTypes不存在的问题。

Fixes #2 #3 